### PR TITLE
chore: only allow triggers on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,14 +27,11 @@ jobs:
           - name: backend
             dir: backend
             triggers: ('backend/')
-            triggers_event: ('pull_request')
           - name: frontend-merge
             dir: frontend
             triggers: ('.')
-            triggers_event: ('pull_request')
           - name: frontend-pr
             dir: frontend
-            triggers_event: ('push')
     steps:
       - uses: actions/checkout@v4
       - uses: ./
@@ -56,4 +53,3 @@ jobs:
             || matrix.name == 'frontend-pr' && secrets.SONAR_TOKEN_FRONTEND
             || '' }}
           triggers: ${{ matrix.triggers }}
-          triggers_event: ${{ matrix.triggers_event }}

--- a/README.md
+++ b/README.md
@@ -78,11 +78,6 @@ Only nodejs (JavaScript, TypeScript) is supported by this action.  Please see ou
     # Useful for consuming non-default branches, like in testing
     # Defants to empty, cloning the default branch
     branch: ""
-
-    # Bash array of events for limiting triggers, otherwise trigger automatically
-    # E.g. ("pull_request" "push" "workflow_dispatch")
-    # Defaults to only using triggers with pull requests
-    triggers_event: "('pull_request')"
 ```
 
 # Example, Single Directory with SonarCloud Analysis
@@ -198,10 +193,6 @@ For BC Government projects, please create an [issue for our platform team](https
 After sign up, a token should be available from your project on the [SonarCloud] site.  Multirepo projects (e.g. backend, frontend) will have multiple projects.  Click `Administration > Analysis Method > GitHub Actions (tutorial)` to find yours.
 
 E.g. https://sonarcloud.io/project/configuration?id={<PROJECT>}&analysisMode=GitHubActions
-
-# Triggers and Triggers_Event
-
-Triggers are used to limit test running to only appropriate files are changed.  This is generally not desirable outside of pull requests, so `triggers_event` defaults to `("pull_request")`.  Override this behaviour by specifying a bash array using any of the many, many [event types GitHub provides](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push), e.g. `("branch_protection_rule" "workflow_dispatch" "push")`.
 
 # Feedback
 

--- a/action.yml
+++ b/action.yml
@@ -78,11 +78,11 @@ runs:
           exit 1
         fi
 
-    # Send triggers to diff action
+    # Send triggers to diff action, but only for pull requests
     - id: diff
       uses: bcgov/action-diff-triggers@v0.2.0
       with:
-        triggers: ${{ github.event_name == 'pull_request' && '' || inputs.triggers }}
+        triggers: ${{ github.event_name == 'pull_request' && inputs.triggers || '' }}
         diff_branch: ${{ inputs.diff_branch }}
 
     # Shallow clone is faster, but SonarCloud requires a full clone

--- a/action.yml
+++ b/action.yml
@@ -49,10 +49,6 @@ inputs:
     description: Non-default branch to clone (used for testing this action)
     default: ""
 
-  triggers_event:
-    description: Events (array) to use with triggers; e.g. ("pull_request" "push" "workflow_dispatch")
-    default: "('pull_request')"
-
 runs:
   using: composite
   steps:
@@ -86,7 +82,7 @@ runs:
     - id: diff
       uses: bcgov/action-diff-triggers@v0.2.0
       with:
-        triggers: ${{ inputs.triggers }}
+        triggers: ${{ github.event_name == 'pull_request' && '' || inputs.triggers }}
         diff_branch: ${{ inputs.diff_branch }}
 
     # Shallow clone is faster, but SonarCloud requires a full clone


### PR DESCRIPTION
Drop `inputs.triggers_event` and always run outside of pull requests.