### PR TITLE
Bump SonarSource/sonarqube-scan-action to v5.3.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,7 @@ runs:
 
     # If sonar_token
     - if: inputs.sonar_token && steps.diff.outputs.triggered == 'true'
-      uses: SonarSource/sonarqube-scan-action@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9 # v5.3.0
+      uses: SonarSource/sonarqube-scan-action@1a6d90ebcb0e6a6b1d87e37ba693fe453195ae25 # v5.3.1
       env:
         SONAR_TOKEN: ${{ inputs.sonar_token }}
       with:


### PR DESCRIPTION
FYI @DerekRoberts @mishraomp 

[Security Advisory: SonarQube Scanner GitHub Action](https://community.sonarsource.com/t/security-advisory-sonarqube-scanner-github-action/147696)

This PR bumps the version of `SonarSource/sonarqube-scan-action` used in `action.yaml` to [v5.3.1](https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v5.3.1).

