### PR TITLE
refactor: remove AI-generated error handling and workspace cleanup cruft

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,36 +106,7 @@ runs:
     - if: steps.diff.outputs.triggered == 'true'
       shell: bash
       working-directory: ${{ inputs.dir }}
-      run: |
-        echo "🚀 Running test commands in ${{ inputs.dir }}..."
-        echo "Commands: ${{ inputs.commands }}"
-
-        # Run Tests with error handling
-        if ! (${{ inputs.commands }}); then
-          echo ""
-          echo "❌ Test commands failed!"
-          echo ""
-          echo "🔧 Common troubleshooting steps:"
-          echo "   1. Check if package.json exists and has test scripts"
-          echo "   2. Verify all dependencies are installed (npm ci)"
-          echo "   3. Check if test files exist and are properly configured"
-          echo "   4. Ensure Node.js version compatibility"
-          echo ""
-          echo "📋 Debug information:"
-          echo "   - Working directory: $(pwd)"
-          echo "   - Node version: $(node --version)"
-          echo "   - NPM version: $(npm --version)"
-          echo "   - Available scripts:"
-          if [ -f package.json ]; then
-            npm run 2>/dev/null | grep -E '^  [a-z]' | head -10 || echo "   (no scripts found)"
-          else
-            echo "   (no package.json found)"
-          fi
-          echo ""
-          exit 1
-        fi
-
-        echo "✅ Test commands completed successfully"
+      run: ${{ inputs.commands }}
 
     ### Optional SonarCloud
 
@@ -149,19 +120,6 @@ runs:
         args: >
           ${{ inputs.sonar_args }}
 
-    ### Cleanup
-
-    # Fix - Docker can take file ownership, causing a cleanup fail
-    - shell: bash
-      if: steps.diff.outputs.triggered == 'true'
-      id: get_uid
-      run: |
-        # User for workstation ownership reset/fix
-        echo "uid=$(id -u ${USER})" >> $GITHUB_OUTPUT
-    - uses: peter-murray/reset-workspace-ownership-action@3c5cbcf2e4aeecb506b3e6bc867e0955dab8dfe0 # v1
-      if: steps.diff.outputs.triggered == 'true'
-      with:
-        user_id: ${{ steps.get_uid.outputs.uid }}
 
     # Fix - Clone for action.yml and other verifications
     - name: Checkout Action repo to pass tests


### PR DESCRIPTION
## Summary

This PR removes AI-generated error handling and 3-year-old workspace cleanup cruft from the Node.js action, bringing it to the same clean, focused approach as the Java action.

## Changes

### Removed AI-Generated Error Handling
- **Enhanced troubleshooting steps** (lines 110-138) - out of scope debugging
- **Complex error handling** with Node.js/npm specific guidance
- **Debug information display** showing versions, scripts, etc.
- **File listing** to help diagnose missing files

### Removed Workspace Cleanup Cruft  
- **Docker file ownership reset** (lines 155-164) - 3-year-old cruft
- **peter-murray/reset-workspace-ownership-action** dependency
- **get_uid step** for workstation ownership reset

## Simplified Approach

**Before:** Complex error handling trying to debug why someone else's tests failed
**After:** Simple `run: ${{ inputs.commands }}` - let it fail naturally

## Benefits

* **Focused responsibility** - we run tests, downstream repos handle failures
* **Consistent with Java action** - same clean, simple approach
* **Reduced complexity** - 43 lines removed, much simpler
* **No out-of-scope debugging** - not our job to troubleshoot their tests
* **No unnecessary dependencies** - removed workspace cleanup action

## Philosophy

As you said: *"Downstream repos are responsible for making sure their tests pass and generate coverage."*

This action should just run the commands and let them fail if they fail. The downstream repo is responsible for making sure their tests work.

## Related

* Achieves parity with clean Java action approach
* Removes technical debt and AI-generated cruft
* Improves maintainability and focus